### PR TITLE
install apks to actually build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3-alpine
 
 COPY requirements.txt /usr/src/app/requirements.txt
 WORKDIR /usr/src/app
-RUN pip install --no-cache -r requirements.txt
+RUN apk add --no-cache git build-base libffi-dev openssl-dev \
+  && pip install --no-cache -r requirements.txt \
+  && apk del git build-base libffi-dev openssl-dev
 
 COPY . /usr/src/app/
 


### PR DESCRIPTION
- git, build-base, openssl-dev, ffi-dev
- uninstall 'em when done

doesn't build the docker without 'em otherwise