### PR TITLE
added logging via hpfeeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 *.pem
 .ropeproject
 venv
+
+.idea/ciscoasa_honeypot.iml
+
+.idea/misc.xml
+
+.idea/modules.xml
+
+.idea/vcs.xml
+
+.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,4 @@
 *.pem
 .ropeproject
 venv
-
-.idea/ciscoasa_honeypot.iml
-
-.idea/misc.xml
-
-.idea/modules.xml
-
-.idea/vcs.xml
-
-.idea/workspace.xml
+.idea/

--- a/README.md
+++ b/README.md
@@ -29,8 +29,17 @@ Options:
                           cert if not supplied)
   -v, --verbose           Verbose logging
   --help                  Show this message and exit.
+  
+  
+Optional settings for hpfeeds logging:  
+  --hpfserver	TEXT			hpfeeds Server
+  --hpfport		INTEGER			hpfeeds Port
+  --hpfident	TEXT			hpfeeds Ident
+  --hpfsecret	TEXT			hpfeeds Secret
+  --hofchannel	TEXT			hpfeeds Channel
+  --serverid	TEXT			hpfeeds Serverid
 ```
-
+The hpfeeds logging options can also be set by using the following os environment variables: HPFEEDS_SERVER, HPFEEDS_PORT, HPFEEDS_IDENT, HPFEEDS_SECRET, HPFEEDS_CHANNEL, SERVERID
 
 See also
 --------

--- a/ike_server.py
+++ b/ike_server.py
@@ -54,11 +54,13 @@ class IKEResponder(asyncio.DatagramProtocol):
         except Exception:
             logger = logging.getLogger()
             logger.debug("unsupported packet")
+            hpfl.log('debug', 'IKE unsupported packet')
             del self.clients[address]
 
 
-def start(host, port, alert, logger):
+def start(host, port, alert, logger, hpfl):
     logger.info('Starting server on port {:d}/udp'.format(port))
+    hpfl.log('info', 'Starting server on port {:d}/udp'.format(port))
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     IKEResponder.alert = alert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click==6.7
 git+git://github.com/Cymmetria/ike
+hpfeeds3


### PR DESCRIPTION
I added hpfeeds support for your ciscoasa_honeypot.

If hpfeeds shall be enabled, you must set either
a) the following environment variables
HPFEEDS_SERVER, HPFEEDS_PORT, HPFEEDS_IDENT, HPFEEDS_SECRET,
HPFEEDS_CHANNEL, SERVERID
or
b) add corresponding arguments --hpfserver, --hpfport, --hpfident,
--hpfsecret, --hpfchannel, --serverid (eq. id/name)

In case they are not set, it will behave as before and only log
locally/stdout.

Hope you find it useful and accept the pull request. Cheers.

